### PR TITLE
invalid key error when including k_detail as argument

### DIFF
--- a/run_handheld.py
+++ b/run_handheld.py
@@ -144,15 +144,16 @@ if __name__ == "__main__":
                                       's2' : args.s2,        
                                       'Mt' : args.Mt,       
                                       }
-    
+   
+    params['merging'] = {'tuning' : {'k_stretch' : args.k_stretch,
+                                     'k_shrink' : args.k_shrink
+                                     }}
+
     if args.k_detail is not None:
         params['merging']['tuning']['k_detail'] = args.k_detail
     if args.k_denoise is not None:
         params['merging']['tuning']['k_denoise'] = args.k_denoise
     
-    params['merging'] = {'tuning' : {'k_stretch' : args.k_stretch,
-                                     'k_shrink' : args.k_shrink
-                                     }}
     params['accumulated robustness denoiser'] = {'on': args.R_denoising_on}
     
     outpath = Path(args.outpath)


### PR DESCRIPTION
params['merging']['tuning'] was getting accessed before initialization leading to a an invalid key error. I moved the code block that initializes this dictionary above where it was getting accessed. Note that it was only getting accesed iff k_detail and/or k_denoise where included as arguments to run_handheld.py.