### PR TITLE
Possible error when calculating pixel distance

### DIFF
--- a/handheld_super_resolution/merge.py
+++ b/handheld_super_resolution/merge.py
@@ -201,17 +201,14 @@ def accumulate_ref(ref_img, covs, bayer_mode, iso_kernel, scale, CFA_pattern,
                 c = ref_img[pixel_idy, pixel_idx]
             
                 # computing distance
-                dist_x = pixel_idx - coarse_ref_sub_pos[1]
-                dist_y = pixel_idy - coarse_ref_sub_pos[0]
+                dist_x = abs(pixel_idx - coarse_ref_sub_pos[1])
+                dist_y = abs(pixel_idy - coarse_ref_sub_pos[0])
             
                 ### Computing w
                 if iso_kernel : 
-                    y = max(0, 2*(dist_x*dist_x + dist_y*dist_y))
+                    y = 2*(dist_x*dist_x + dist_y*dist_y)
                 else:
-                    y = max(0, quad_mat_prod(cov_i, dist_x, dist_y))
-                    # y can be slightly negative because of numerical precision.
-                    # I clamp it to not explode the error with exp
-                    
+                    y = quad_mat_prod(cov_i, dist_x, dist_y)
                 
                 # this is equivalent to multiplying the covariance,
                 # but at the cost of one scalar operation (instead of 4)

--- a/handheld_super_resolution/merge.py
+++ b/handheld_super_resolution/merge.py
@@ -428,16 +428,14 @@ def accumulate(comp_img, alignments, covs, r,
                 c = comp_img[pixel_idy, pixel_idx]
             
                 # computing distance
-                dist_x = pixel_idx - patch_center_pos[1]
-                dist_y = pixel_idy - patch_center_pos[0]
+                dist_x = abs(pixel_idx - patch_center_pos[1])
+                dist_y = abs(pixel_idy - patch_center_pos[0])
             
                 ### Computing w
                 if iso_kernel : 
-                    y = max(0, 2*(dist_x*dist_x + dist_y*dist_y))
+                    y = 2*(dist_x*dist_x + dist_y*dist_y)
                 else:
-                    y = max(0, quad_mat_prod(cov_i, dist_x, dist_y))
-                    # y can be slightly negative because of numerical precision.
-                    # I clamp it to not explode the error with exp
+                    y = quad_mat_prod(cov_i, dist_x, dist_y)
  
                 w = math.exp(-0.5*y)
 


### PR DESCRIPTION
**I'm guessing this is an error, but I'm not 100% sure so please review this carefully.** 

The important fix is taking the absolute values when declaring dist_x and dist_y. The change on the lines declaring y is just to remove the now unecessary max() calls.